### PR TITLE
chore: update attribution string

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -25,6 +25,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/load-balanced-vms/v0.0.1"
+    module_name = "blueprints/terraform/terraform-google-load-balanced-vms/v0.0.1"
   }
 }


### PR DESCRIPTION
We use the `terraform-google-` prefix in attribution strings