### PR TITLE
chore: fix tflint issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-
-data "google_project" "project" {
-  project_id = var.project_id
-}
-
 locals {
   default_machine_type = "e2-medium"
 }
@@ -105,7 +100,7 @@ resource "google_compute_snapshot" "main" {
   name              = "${var.deployment_name}-snapshot"
   source_disk       = google_compute_instance.exemplar.boot_disk[0].device_name
   zone              = var.zone
-  storage_locations = ["${var.region}"]
+  storage_locations = [var.region]
   depends_on        = [time_sleep.startup_completion]
   labels            = var.labels
 }

--- a/versions.tf
+++ b/versions.tf
@@ -18,13 +18,27 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
-      # TODO: Check why this filter was breaking tests.
-      # version = "~> 3.53, < 5.0"
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.5"
     }
   }
 
   provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-load-balanced-vms/v0.1.1"
+  }
+  provider_meta "google-beta" {
     module_name = "blueprints/terraform/terraform-google-load-balanced-vms/v0.1.1"
   }
 }


### PR DESCRIPTION
We started rolling out tflint and this fixes a few issues discovered. @tpryan I also added the TPG/B constraints but you may want to further constrain them if there is any min version you needed for a feature.

```
Checking for tflint
Working in . ...
6 issue(s) found:

Warning: data "google_project" "project" is declared but not used (terraform_unused_declarations)

  on main.tf line 18:
  18: data "google_project" "project" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_unused_declarations.md

Warning: Missing version constraint for provider "local" in "required_providers" (terraform_required_providers)

  on main.tf line 62:
  62: data "local_file" "index" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "time" in "required_providers" (terraform_required_providers)

  on main.tf line 98:
  98: resource "time_sleep" "startup_completion" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_required_providers.md

Warning: Interpolation-only expressions are deprecated in Terraform v0.12.14 (terraform_deprecated_interpolation)

  on main.tf line 108:
 108:   storage_locations = ["${var.region}"]

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_deprecated_interpolation.md

Warning: Missing version constraint for provider "google" in "required_providers" (terraform_required_providers)

  on main.tf line 124:
 124: resource "google_compute_instance_template" "main" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "google-beta" in "required_providers" (terraform_required_providers)

  on main.tf line 155:
 155: resource "google_compute_instance_group_manager" "main" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_required_providers.md

tflint failed . 
Working in ./examples/simple_example ...
tflint passed ./examples/simple_example 
```