### PR TITLE
chore: Add a test to verify multiple deployments in a single project

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -33,6 +33,9 @@ steps:
 - id: simple-example-teardown
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage teardown --verbose']
+- id: multiple-deploy
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestMultipleDeploy --verbose']
 tags:
 - 'ci'
 - 'integration'

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -7,6 +7,7 @@ This example illustrates how to use the `load-balanced-vms` module.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| deployment\_name | Deployment name | `string` | `"deployment_name"` | no |
 | project\_id | The project ID to deploy to | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -17,9 +17,10 @@
 module "load_balanced_vms" {
   source = "../.."
 
-  project_id      = var.project_id
-  region          = "us-central1"
-  zone            = "us-central1-a"
-  nodes           = "3"
-  deployment_name = "load-balanced-vms"
+  project_id = var.project_id
+  region     = "us-central1"
+  zone       = "us-central1-a"
+  nodes      = "3"
+  // param for testing multiple deployments in a single project
+  deployment_name = var.deployment_name
 }

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -22,5 +22,5 @@ variable "project_id" {
 variable "deployment_name" {
   type        = string
   description = "Deployment name"
-  default     = "deployment_name"
+  default     = "load-balanced-vms"
 }

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -18,3 +18,9 @@ variable "project_id" {
   type        = string
   description = "The project ID to deploy to"
 }
+
+variable "deployment_name" {
+  type        = string
+  description = "Deployment name"
+  default     = "deployment_name"
+}

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@
 
 locals {
   default_machine_type = "e2-medium"
+  subnet_name          = "${var.deployment_name}-subnet-01"
 }
 
 # Enabling services in your GCP project
@@ -42,7 +43,7 @@ module "vpc" {
 
   subnets = [
     {
-      subnet_name   = "subnet-01"
+      subnet_name   = local.subnet_name
       subnet_ip     = "10.10.10.0/24"
       subnet_region = var.region
     }
@@ -80,7 +81,7 @@ resource "google_compute_instance" "exemplar" {
   }
 
   network_interface {
-    subnetwork         = module.vpc.subnets["${var.region}/subnet-01"].self_link
+    subnetwork         = module.vpc.subnets["${var.region}/${local.subnet_name}"].self_link
     subnetwork_project = var.project_id
     access_config {
       // Ephemeral public IP
@@ -137,7 +138,7 @@ resource "google_compute_instance_template" "main" {
   }
 
   network_interface {
-    subnetwork         = module.vpc.subnets["${var.region}/subnet-01"].self_link
+    subnetwork         = module.vpc.subnets["${var.region}/${local.subnet_name}"].self_link
     subnetwork_project = var.project_id
     access_config {
       // Ephemeral public IP

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-google-modules/load-balanced-vms/test/integration
 go 1.16
 
 require (
-	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.2.0
+	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221123030738-ec41d54f4817
 	github.com/hashicorp/go-getter v1.6.2 // indirect
 	github.com/stretchr/testify v1.7.0
 )

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -67,6 +67,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.2.0 h1:lBn3C9bNzvcBOAlDjTFfOJktmYMlaohaCmPfTPjttek=
 github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.2.0/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221122171254-c2f6d8f25e6b h1:3AJxSllGmYXaIVeb3Cvmtye82G2H32TLuxMRbRhffZI=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221122171254-c2f6d8f25e6b/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221123030738-ec41d54f4817 h1:NhFWM0B3KjLRk5wtxoIMHUhYs/USsmUK88HHJDbFseE=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221123030738-ec41d54f4817/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
 github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20220301220754-6964a09d6cd2/go.mod h1:lJYiqfBOl6AOiefK9kmkhinbffIysu+nnclOBwKEPlQ=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/test/integration/simple_example/multiple_deploy_test.go
+++ b/test/integration/simple_example/multiple_deploy_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simple_example
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+)
+
+func TestMultipleDeploy(t *testing.T) {
+	multipleDeployExample := tft.NewTFBlueprintTest(t)
+	// RedeployTest will first perform the init, apply, verify stages
+	// in two different TF workspaces and then teardown.
+	// No custom verification performed here as that is handled in simple example.
+	multipleDeployExample.RedeployTest(2, map[int]map[string]interface{}{
+		1: {"deployment_name": "deployment-1"},
+		2: {"deployment_name": "deployment-2"},
+	})
+}

--- a/test/integration/simple_example/simple_example_test.go
+++ b/test/integration/simple_example/simple_example_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package multiple_buckets
+package simple_example
 
 import (
 	"fmt"


### PR DESCRIPTION
This uses a new helper in the test framework to deploy a blueprint multiple times within the same project to verify no resource conflicts.