### PR TITLE
chore: pin tftest back to a released version

### DIFF
--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-google-modules/load-balanced-vms/test/integration
 go 1.16
 
 require (
-	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221123030738-ec41d54f4817
+	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.4.0
 	github.com/hashicorp/go-getter v1.6.2 // indirect
 	github.com/stretchr/testify v1.7.0
 )

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -71,6 +71,8 @@ github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.
 github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221122171254-c2f6d8f25e6b/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
 github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221123030738-ec41d54f4817 h1:NhFWM0B3KjLRk5wtxoIMHUhYs/USsmUK88HHJDbFseE=
 github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221123030738-ec41d54f4817/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.4.0 h1:739vuqwRvwUbNvZltlvRZNLyjmutdc323VNCaGDEKaw=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.4.0/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
 github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20220301220754-6964a09d6cd2/go.mod h1:lJYiqfBOl6AOiefK9kmkhinbffIysu+nnclOBwKEPlQ=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=


### PR DESCRIPTION
I pinned to pseudo version while iterating, switching this back to a release version.